### PR TITLE
Add Chargebee as alternative billing provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Production-ready Flask SaaS template**
 
-Multi-tenant workspaces, Stripe billing, OAuth, and team collaboration out of the box. Build your product, not infrastructure.
+Multi-tenant workspaces, subscription billing (Stripe or Chargebee), OAuth, and team collaboration out of the box. Build your product, not infrastructure.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -21,7 +21,7 @@ https://github.com/user-attachments/assets/c955e2a2-8f25-4430-98fe-5bbc95ffb4da
 ## What's Included
 
 - **Multi-tenant workspaces** - Data isolation, scales from solo to teams
-- **Stripe billing** - Checkout, webhooks, customer portal
+- **Subscription billing** - Stripe or Chargebee, hosted checkout, webhooks, customer portal
 - **OAuth authentication** - Google & GitHub login
 - **Team collaboration** - Roles (admin/member), member management
 - **Modern stack** - Flask 3.1, Vue 3, Vuetify 3, PostgreSQL, Redis
@@ -48,6 +48,9 @@ cd readykit
 # 2. Configure (edit .env)
 GOOGLE_OAUTH_CLIENT_ID=your_id
 GOOGLE_OAUTH_CLIENT_SECRET=your_secret
+
+# Billing: choose stripe (default) or chargebee
+BILLING_PROVIDER=stripe
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_PRO_PRICE_ID=price_...
 

--- a/checks.py
+++ b/checks.py
@@ -100,7 +100,17 @@ def check_billing_service(app):
 
     assert callable(requires_pro_plan)
     assert hasattr(HostedBilling, "create_upgrade_session")
+    assert hasattr(HostedBilling, "create_portal_session")
     assert hasattr(HostedBilling, "handle_successful_payment")
+
+
+@check("BillingEvent model exists")
+def check_billing_event_model(app):
+    from enferno.user.models import BillingEvent
+
+    with app.app_context():
+        assert hasattr(BillingEvent, "provider")
+        BillingEvent.query.limit(1).all()
 
 
 @check("Auth decorators work")
@@ -127,10 +137,14 @@ def check_routes(app):
         "/",
         "/login",
         "/dashboard/",
-        "/stripe/webhook",
     ]
+
     for route in critical_routes:
         assert route in rules, f"Missing route: {route}"
+
+    # Billing webhook - one of these must exist based on provider
+    webhook_routes = ["/stripe/webhook", "/chargebee/webhook"]
+    assert any(r in rules for r in webhook_routes), "Missing billing webhook route"
 
 
 @check("Security config is sane")

--- a/docs/billing.md
+++ b/docs/billing.md
@@ -1,10 +1,21 @@
 # Billing
 
-Stripe integration for subscriptions and payments.
+Subscription billing with Stripe or Chargebee.
 
 ## Overview
 
-ReadyKit uses Stripe's hosted pages for billing - no custom checkout UI to build or maintain. Users upgrade via Stripe Checkout and manage subscriptions through the Stripe Customer Portal.
+ReadyKit uses hosted payment pages - no custom checkout UI to build or maintain. Users upgrade via the provider's checkout page and manage subscriptions through their portal.
+
+::: warning Choose Your Provider First
+Select your billing provider before going to production. Switching providers after users have subscribed requires manual migration of customer data. Set `BILLING_PROVIDER` in your environment and stick with it.
+:::
+
+## Supported Providers
+
+| Provider | Best For |
+|----------|----------|
+| **Stripe** | Most SaaS apps, US/EU focus, extensive API |
+| **Chargebee** | Complex billing needs, subscription management, international |
 
 ## Plans
 
@@ -31,6 +42,8 @@ From [Stripe Dashboard](https://dashboard.stripe.com):
 
 ```bash
 # .env
+BILLING_PROVIDER=stripe
+
 STRIPE_SECRET_KEY=sk_test_...
 STRIPE_PUBLISHABLE_KEY=pk_test_...
 STRIPE_PRO_PRICE_ID=price_...
@@ -45,7 +58,7 @@ PRO_PRICE_INTERVAL=month
 
 In Stripe Dashboard → Webhooks → Add endpoint:
 
-- **URL**: `https://yourdomain.com/api/webhooks/stripe/webhook`
+- **URL**: `https://yourdomain.com/stripe/webhook`
 - **Events to listen for**:
   - `checkout.session.completed`
   - `customer.subscription.deleted`
@@ -53,17 +66,60 @@ In Stripe Dashboard → Webhooks → Add endpoint:
 
 Copy the signing secret to `STRIPE_WEBHOOK_SECRET`.
 
+## Chargebee Setup
+
+### 1. Get Your Credentials
+
+From [Chargebee Dashboard](https://app.chargebee.com):
+
+1. **Settings → API Keys** → Copy your API key
+2. **Product Catalog → Items** → Create an item with a price
+3. **Settings → Webhooks** → Add endpoint (see below)
+
+### 2. Configure Environment
+
+```bash
+# .env
+BILLING_PROVIDER=chargebee
+
+CHARGEBEE_SITE=your-site          # e.g., "acme" for acme.chargebee.com
+CHARGEBEE_API_KEY=your_api_key
+CHARGEBEE_PRO_ITEM_PRICE_ID=Pro-Plan-USD-Monthly
+
+# Webhook authentication (required in production)
+CHARGEBEE_WEBHOOK_USERNAME=webhook_user
+CHARGEBEE_WEBHOOK_PASSWORD=your_secure_password
+
+# Display values (shown in UI)
+PRO_PRICE_DISPLAY=$29
+PRO_PRICE_INTERVAL=month
+```
+
+### 3. Set Up Webhook
+
+In Chargebee Dashboard → Settings → Webhooks → Add webhook:
+
+- **URL**: `https://yourdomain.com/chargebee/webhook`
+- **Authentication**: Basic Auth with your configured username/password
+- **Events to listen for**:
+  - `subscription_cancelled`
+  - `payment_failed`
+
+::: info Chargebee Webhook Security
+Chargebee uses HTTP Basic Auth for webhook verification (not HMAC signatures like Stripe). Always configure `CHARGEBEE_WEBHOOK_USERNAME` and `CHARGEBEE_WEBHOOK_PASSWORD` in production. Unauthenticated webhooks are only allowed in debug mode for local testing.
+:::
+
 ## How Billing Works
 
 ### Upgrade Flow
 
 ```
 User clicks "Upgrade"
-    → Create Stripe Checkout session
-    → Redirect to Stripe
+    → Create checkout session
+    → Redirect to provider's hosted page
     → User completes payment
-    → Stripe redirects to success URL
-    → Validate session_id
+    → Provider redirects to success URL
+    → Validate session
     → Upgrade workspace to Pro
 ```
 
@@ -83,12 +139,13 @@ def upgrade(workspace_id):
 
 ### Success Callback
 
-The success URL includes a `session_id` that's validated server-side:
+The success URL includes a session ID that's validated server-side:
 
 ```python
 @app.route("/billing/success")
 def billing_success():
-    session_id = request.args.get("session_id")
+    # Works with both Stripe (session_id) and Chargebee (id)
+    session_id = request.args.get("session_id") or request.args.get("id")
     workspace_id = HostedBilling.handle_successful_payment(session_id)
 
     if workspace_id:
@@ -100,12 +157,12 @@ def billing_success():
 ```
 
 ::: info
-The `session_id` is the security token. Always validate it via Stripe API before upgrading - never trust URL parameters directly.
+The session ID is the security token. Always validate it via the provider's API before upgrading - never trust URL parameters directly.
 :::
 
 ### Manage Billing (Customer Portal)
 
-Existing Pro users can manage their subscription through Stripe's Customer Portal:
+Existing Pro users can manage their subscription through the provider's portal:
 
 ```python
 @app.route("/workspace/<int:workspace_id>/billing/")
@@ -113,11 +170,11 @@ Existing Pro users can manage their subscription through Stripe's Customer Porta
 def manage_billing(workspace_id):
     workspace = g.current_workspace
 
-    if not workspace.stripe_customer_id:
+    if not workspace.billing_customer_id:
         return redirect(url_for("portal.upgrade", workspace_id=workspace_id))
 
     session = HostedBilling.create_portal_session(
-        customer_id=workspace.stripe_customer_id,
+        customer_id=workspace.billing_customer_id,
         workspace_id=workspace_id,
         base_url=request.host_url
     )
@@ -128,20 +185,37 @@ def manage_billing(workspace_id):
 
 Webhooks update workspace status automatically when billing changes:
 
+### Stripe Events
+
 | Event | Action |
 |-------|--------|
 | `checkout.session.completed` | Upgrade workspace to Pro, save customer_id |
 | `customer.subscription.deleted` | Downgrade workspace to Free |
 | `invoice.payment_failed` | Downgrade workspace to Free |
 
+### Chargebee Events
+
+| Event | Action |
+|-------|--------|
+| `subscription_cancelled` | Downgrade workspace to Free |
+| `payment_failed` | Downgrade workspace to Free |
+
+::: tip Chargebee Upgrades
+Chargebee upgrades are handled via the redirect flow only (not webhooks). This is intentional - the webhook would arrive after the redirect in most cases anyway.
+:::
+
 ### Idempotency
 
-Webhooks are idempotent - duplicate events are safely ignored using the `StripeEvent` model:
+Webhooks are idempotent - duplicate events are safely ignored using the `BillingEvent` model:
 
 ```python
 # Duplicate events are caught by unique constraint
 try:
-    db.session.add(StripeEvent(event_id=event_id, event_type=event.type))
+    db.session.add(BillingEvent(
+        event_id=event_id,
+        event_type=event_type,
+        provider="stripe"  # or "chargebee"
+    ))
     db.session.commit()
 except IntegrityError:
     db.session.rollback()
@@ -173,6 +247,8 @@ For web pages, it redirects to the upgrade page.
 
 ## Testing Locally
 
+### Stripe
+
 Use [Stripe CLI](https://stripe.com/docs/stripe-cli) to test webhooks locally:
 
 ```bash
@@ -183,12 +259,28 @@ brew install stripe/stripe-cli/stripe
 stripe login
 
 # Forward webhooks to local server
-stripe listen --forward-to localhost:5000/api/webhooks/stripe/webhook
+stripe listen --forward-to localhost:5000/stripe/webhook
 
 # In another terminal, trigger test events
 stripe trigger checkout.session.completed
 stripe trigger customer.subscription.deleted
 ```
+
+### Chargebee
+
+Use [ngrok](https://ngrok.com) to expose your local server:
+
+```bash
+# Start ngrok
+ngrok http 5000
+
+# In Chargebee Dashboard:
+# 1. Add webhook URL: https://your-ngrok-url.ngrok.io/chargebee/webhook
+# 2. Set Basic Auth credentials matching your .env
+# 3. Trigger test events from the webhook settings page
+```
+
+For local testing without authentication, set `FLASK_DEBUG=1` - webhooks will be accepted without Basic Auth in debug mode.
 
 ## Checking Plan Status
 
@@ -217,10 +309,20 @@ if workspace.is_pro:
 class Workspace(db.Model):
     # Billing fields
     plan = db.Column(db.String(20), default="free")  # "free" or "pro"
-    stripe_customer_id = db.Column(db.String(255))    # Stripe customer ID
-    upgraded_at = db.Column(db.DateTime)              # When they upgraded
+    billing_customer_id = db.Column(db.String(255))  # Provider customer ID
+    upgraded_at = db.Column(db.DateTime)             # When they upgraded
 
     @property
     def is_pro(self):
         return self.plan == "pro"
 ```
+
+## Provider Comparison
+
+| Feature | Stripe | Chargebee |
+|---------|--------|-----------|
+| Webhook auth | HMAC signature | Basic Auth |
+| Upgrade via | Redirect + Webhook | Redirect only |
+| Portal URL field | `.url` | `.access_url` (wrapped) |
+| Session param | `session_id` | `id` |
+| Customer ID location | `session.customer` | `hosted_page.content["customer"]["id"]` |

--- a/enferno/api/webhooks.py
+++ b/enferno/api/webhooks.py
@@ -13,6 +13,8 @@ PROVIDER = os.environ.get("BILLING_PROVIDER", "stripe")
 if PROVIDER == "stripe":
     import stripe
 
+    from enferno.services.billing import HostedBilling
+
     @webhooks_bp.route("/stripe/webhook", methods=["POST"])
     def stripe_webhook():
         payload = request.get_data()

--- a/enferno/api/webhooks.py
+++ b/enferno/api/webhooks.py
@@ -3,7 +3,7 @@ from flask import Blueprint, current_app, request
 from sqlalchemy.exc import IntegrityError
 
 from enferno.extensions import db
-from enferno.user.models import StripeEvent
+from enferno.user.models import BillingEvent
 
 webhooks_bp = Blueprint("webhooks", __name__)
 
@@ -27,7 +27,7 @@ def stripe_webhook():
     # Skip duplicate events
     event_id = event.get("id")
     try:
-        db.session.add(StripeEvent(event_id=event_id, event_type=event.get("type")))
+        db.session.add(BillingEvent(event_id=event_id, event_type=event.get("type"), provider="stripe"))
         db.session.commit()
     except IntegrityError:
         db.session.rollback()

--- a/enferno/api/webhooks.py
+++ b/enferno/api/webhooks.py
@@ -51,7 +51,7 @@ def stripe_webhook():
         from enferno.user.models import Workspace
 
         workspace = db.session.execute(
-            db.select(Workspace).where(Workspace.stripe_customer_id == customer_id)
+            db.select(Workspace).where(Workspace.billing_customer_id == customer_id)
         ).scalar_one_or_none()
 
         if workspace:
@@ -69,7 +69,7 @@ def stripe_webhook():
         from enferno.user.models import Workspace
 
         workspace = db.session.execute(
-            db.select(Workspace).where(Workspace.stripe_customer_id == customer_id)
+            db.select(Workspace).where(Workspace.billing_customer_id == customer_id)
         ).scalar_one_or_none()
 
         if workspace and workspace.plan == "pro":

--- a/enferno/portal/views.py
+++ b/enferno/portal/views.py
@@ -433,7 +433,7 @@ def upgrade_workspace(workspace_id):
 
     workspace = g.current_workspace
     current_app.logger.debug(
-        f"Current workspace plan: {workspace.plan}, stripe_customer_id: {workspace.stripe_customer_id}"
+        f"Current workspace plan: {workspace.plan}, billing_customer_id: {workspace.billing_customer_id}"
     )
 
     # Prevent duplicate subscriptions - redirect to billing portal if already Pro
@@ -442,7 +442,7 @@ def upgrade_workspace(workspace_id):
             f"Workspace {workspace_id} already on Pro plan, redirecting to billing portal"
         )
         # Only redirect if we have a customer ID, otherwise show settings
-        if workspace.stripe_customer_id:
+        if workspace.billing_customer_id:
             return redirect(url_for("portal.billing_portal", workspace_id=workspace_id))
         else:
             # Pro workspace without Stripe customer (manual upgrade, legacy)
@@ -472,10 +472,10 @@ def upgrade_workspace(workspace_id):
 def billing_portal(workspace_id):
     """Redirect to Stripe Customer Portal - fully hosted"""
     workspace = g.current_workspace
-    if workspace.stripe_customer_id:
+    if workspace.billing_customer_id:
         try:
             session = HostedBilling.create_portal_session(
-                workspace.stripe_customer_id, workspace_id, request.url_root
+                workspace.billing_customer_id, workspace_id, request.url_root
             )
             return redirect(session.url)
         except Exception as e:

--- a/enferno/portal/views.py
+++ b/enferno/portal/views.py
@@ -510,8 +510,9 @@ def billing_portal(workspace_id):
 @portal.get("/billing/success")
 @auth_required("session")
 def billing_success():
-    """Handle successful Stripe checkout - validate and upgrade workspace"""
-    session_id = request.args.get("session_id")
+    """Handle successful checkout - validate and upgrade workspace"""
+    # Stripe uses ?session_id=, Chargebee uses ?id=
+    session_id = request.args.get("session_id") or request.args.get("id")
 
     if not session_id:
         return redirect("/dashboard")

--- a/enferno/services/billing.py
+++ b/enferno/services/billing.py
@@ -1,115 +1,208 @@
 """
-Ultra-minimal Stripe billing service using hosted pages.
+Billing service with provider support (Stripe or Chargebee).
+Uses hosted pages - no custom checkout UI.
 """
 
+import json
+import os
 from datetime import datetime
 from functools import wraps
 from typing import Any
 
-import stripe
 from flask import current_app, jsonify, redirect, request, url_for
 
 from enferno.extensions import db
 from enferno.services.workspace import get_current_workspace
 from enferno.user.models import Workspace
 
+PROVIDER = os.environ.get("BILLING_PROVIDER", "stripe")
 
-def _init_stripe():
-    """Initialize Stripe API key from config"""
-    secret = current_app.config.get("STRIPE_SECRET_KEY")
-    if not secret:
-        raise RuntimeError("Stripe is not configured")
-    stripe.api_key = secret
+if PROVIDER == "stripe":
+    import stripe
 
+    def _init_stripe():
+        """Initialize Stripe API key from config"""
+        secret = current_app.config.get("STRIPE_SECRET_KEY")
+        if not secret:
+            raise RuntimeError("Stripe is not configured")
+        stripe.api_key = secret
 
-class HostedBilling:
-    """Minimal billing service using Stripe's hosted pages."""
+    class HostedBilling:
+        """Billing service using Stripe's hosted pages."""
 
-    @staticmethod
-    def create_upgrade_session(
-        workspace_id: int, user_email: str, base_url: str
-    ) -> Any:
-        """Create Stripe Checkout session for workspace upgrade."""
-        _init_stripe()
-        price_id = current_app.config.get("STRIPE_PRO_PRICE_ID")
-        if not price_id:
-            raise RuntimeError("Stripe price not configured")
+        @staticmethod
+        def create_upgrade_session(
+            workspace_id: int, user_email: str, base_url: str
+        ) -> Any:
+            """Create Stripe Checkout session for workspace upgrade."""
+            _init_stripe()
+            price_id = current_app.config.get("STRIPE_PRO_PRICE_ID")
+            if not price_id:
+                raise RuntimeError("Stripe price not configured")
 
-        session = stripe.checkout.Session.create(
-            customer_email=user_email,
-            line_items=[{"price": price_id, "quantity": 1}],
-            mode="subscription",
-            success_url=f"{base_url}billing/success?session_id={{CHECKOUT_SESSION_ID}}",
-            cancel_url=f"{base_url}dashboard",
-            metadata={"workspace_id": str(workspace_id)},
-        )
-        current_app.logger.info(f"Created Stripe Checkout session: {session.id}")
-        return session
-
-    @staticmethod
-    def create_portal_session(
-        customer_id: str, workspace_id: int, base_url: str
-    ) -> Any:
-        """Create Stripe Customer Portal session for billing management."""
-        _init_stripe()
-        session = stripe.billing_portal.Session.create(
-            customer=customer_id,
-            return_url=f"{base_url}workspace/{workspace_id}/settings",
-        )
-        current_app.logger.info(f"Created Stripe Portal session: {session.id}")
-        return session
-
-    @staticmethod
-    def handle_successful_payment(session_id: str) -> int:
-        """Handle successful Stripe payment by upgrading the workspace.
-
-        Security: session_id is the security token - validated via Stripe API.
-
-        Returns:
-            Workspace ID if successful, None otherwise
-        """
-        _init_stripe()
-        session = stripe.checkout.Session.retrieve(session_id)
-        current_app.logger.info(
-            f"Processing checkout: {session.id} status={session.status} payment={session.payment_status}"
-        )
-
-        # Verify payment actually completed
-        if session.status != "complete":
-            current_app.logger.warning(
-                f"Checkout session not complete: {session.id} status={session.status}"
+            session = stripe.checkout.Session.create(
+                customer_email=user_email,
+                line_items=[{"price": price_id, "quantity": 1}],
+                mode="subscription",
+                success_url=f"{base_url}billing/success?session_id={{CHECKOUT_SESSION_ID}}",
+                cancel_url=f"{base_url}dashboard",
+                metadata={"workspace_id": str(workspace_id)},
             )
-            return None
+            current_app.logger.info(f"Created Stripe Checkout session: {session.id}")
+            return session
 
-        if session.payment_status not in {"paid", "no_payment_required"}:
-            current_app.logger.warning(
-                f"Payment not confirmed: {session.id} payment_status={session.payment_status}"
+        @staticmethod
+        def create_portal_session(
+            customer_id: str, workspace_id: int, base_url: str
+        ) -> Any:
+            """Create Stripe Customer Portal session for billing management."""
+            _init_stripe()
+            session = stripe.billing_portal.Session.create(
+                customer=customer_id,
+                return_url=f"{base_url}workspace/{workspace_id}/settings",
             )
-            return None
+            current_app.logger.info(f"Created Stripe Portal session: {session.id}")
+            return session
 
-        workspace_id = session.metadata.get("workspace_id")
-        if not workspace_id:
-            return None
+        @staticmethod
+        def handle_successful_payment(session_id: str) -> int:
+            """Handle successful Stripe payment by upgrading the workspace."""
+            _init_stripe()
+            session = stripe.checkout.Session.retrieve(session_id)
+            current_app.logger.info(
+                f"Processing checkout: {session.id} status={session.status} payment={session.payment_status}"
+            )
 
-        workspace = db.session.get(Workspace, int(workspace_id))
-        if not workspace:
-            return None
+            if session.status != "complete":
+                current_app.logger.warning(
+                    f"Checkout session not complete: {session.id} status={session.status}"
+                )
+                return None
 
-        # Idempotent: if already pro, just return success
-        if workspace.is_pro:
-            return workspace.id
+            if session.payment_status not in {"paid", "no_payment_required"}:
+                current_app.logger.warning(
+                    f"Payment not confirmed: {session.id} payment_status={session.payment_status}"
+                )
+                return None
 
-        # Upgrade workspace
-        try:
-            workspace.plan = "pro"
-            workspace.billing_customer_id = session.customer
-            workspace.upgraded_at = datetime.utcnow()
-            db.session.commit()
-            return workspace.id
-        except Exception as e:
-            db.session.rollback()
-            current_app.logger.error(f"Failed to upgrade workspace {workspace_id}: {e}")
-            return None
+            workspace_id = session.metadata.get("workspace_id")
+            if not workspace_id:
+                return None
+
+            workspace = db.session.get(Workspace, int(workspace_id))
+            if not workspace:
+                return None
+
+            if workspace.is_pro:
+                return workspace.id
+
+            try:
+                workspace.plan = "pro"
+                workspace.billing_customer_id = session.customer
+                workspace.upgraded_at = datetime.utcnow()
+                db.session.commit()
+                return workspace.id
+            except Exception as e:
+                db.session.rollback()
+                current_app.logger.error(f"Failed to upgrade workspace {workspace_id}: {e}")
+                return None
+
+elif PROVIDER == "chargebee":
+    from chargebee import Chargebee
+
+    _cb_client = None
+
+    def _init_chargebee():
+        """Initialize Chargebee client from config"""
+        global _cb_client
+        if _cb_client is None:
+            api_key = current_app.config.get("CHARGEBEE_API_KEY")
+            site = current_app.config.get("CHARGEBEE_SITE")
+            if not api_key or not site:
+                raise RuntimeError("Chargebee is not configured")
+            _cb_client = Chargebee(api_key=api_key, site=site)
+        return _cb_client
+
+    class HostedBilling:
+        """Billing service using Chargebee's hosted pages."""
+
+        @staticmethod
+        def create_upgrade_session(
+            workspace_id: int, user_email: str, base_url: str
+        ) -> Any:
+            """Create Chargebee Checkout session for workspace upgrade."""
+            cb = _init_chargebee()
+            item_price_id = current_app.config.get("CHARGEBEE_PRO_ITEM_PRICE_ID")
+            if not item_price_id:
+                raise RuntimeError("Chargebee item price not configured")
+
+            result = cb.HostedPage.checkout_new_for_items({
+                "subscription_items": [{"item_price_id": item_price_id}],
+                "customer": {"email": user_email},
+                "redirect_url": f"{base_url}billing/success",  # Chargebee appends ?id=xxx&state=yyy
+                "cancel_url": f"{base_url}dashboard",
+                "pass_thru_content": json.dumps({"workspace_id": str(workspace_id)}),
+            })
+            hosted_page = result.hosted_page
+            current_app.logger.info(f"Created Chargebee Checkout: {hosted_page.id}")
+            return hosted_page
+
+        @staticmethod
+        def create_portal_session(
+            customer_id: str, workspace_id: int, base_url: str
+        ) -> Any:
+            """Create Chargebee Portal session for billing management."""
+            cb = _init_chargebee()
+            result = cb.PortalSession.create({
+                "customer": {"id": customer_id},
+                "redirect_url": f"{base_url}workspace/{workspace_id}/settings",
+            })
+            portal_session = result.portal_session
+            current_app.logger.info(f"Created Chargebee Portal session: {portal_session.id}")
+            return portal_session
+
+        @staticmethod
+        def handle_successful_payment(hosted_page_id: str) -> int:
+            """Handle successful Chargebee payment by upgrading the workspace."""
+            cb = _init_chargebee()
+            result = cb.HostedPage.retrieve(hosted_page_id)
+            hosted_page = result.hosted_page
+            current_app.logger.info(
+                f"Processing Chargebee checkout: {hosted_page.id} state={hosted_page.state}"
+            )
+
+            if hosted_page.state != "succeeded":
+                current_app.logger.warning(
+                    f"Checkout not succeeded: {hosted_page.id} state={hosted_page.state}"
+                )
+                return None
+
+            pass_thru = json.loads(hosted_page.pass_thru_content or "{}")
+            workspace_id = pass_thru.get("workspace_id")
+            if not workspace_id:
+                return None
+
+            workspace = db.session.get(Workspace, int(workspace_id))
+            if not workspace:
+                return None
+
+            if workspace.is_pro:
+                return workspace.id
+
+            try:
+                workspace.plan = "pro"
+                # Chargebee content is dict-like: content["customer"]["id"]
+                workspace.billing_customer_id = hosted_page.content["customer"]["id"]
+                workspace.upgraded_at = datetime.utcnow()
+                db.session.commit()
+                return workspace.id
+            except Exception as e:
+                db.session.rollback()
+                current_app.logger.error(f"Failed to upgrade workspace {workspace_id}: {e}")
+                return None
+
+else:
+    raise RuntimeError(f"Unknown BILLING_PROVIDER: {PROVIDER}")
 
 
 def requires_pro_plan(f):

--- a/enferno/services/billing.py
+++ b/enferno/services/billing.py
@@ -102,7 +102,7 @@ class HostedBilling:
         # Upgrade workspace
         try:
             workspace.plan = "pro"
-            workspace.stripe_customer_id = session.customer
+            workspace.billing_customer_id = session.customer
             workspace.upgraded_at = datetime.utcnow()
             db.session.commit()
             return workspace.id

--- a/enferno/settings.py
+++ b/enferno/settings.py
@@ -146,12 +146,22 @@ class Config:
     GITHUB_OAUTH_CLIENT_ID = os.environ.get("GITHUB_OAUTH_CLIENT_ID")
     GITHUB_OAUTH_CLIENT_SECRET = os.environ.get("GITHUB_OAUTH_CLIENT_SECRET")
 
-    # Stripe Settings
+    # Billing Provider: 'stripe' or 'chargebee'
+    BILLING_PROVIDER = os.environ.get("BILLING_PROVIDER", "stripe")
+
+    # Stripe Settings (if BILLING_PROVIDER=stripe)
     STRIPE_PUBLISHABLE_KEY = os.environ.get("STRIPE_PUBLISHABLE_KEY")
     STRIPE_SECRET_KEY = os.environ.get("STRIPE_SECRET_KEY")
     STRIPE_PRO_PRICE_ID = os.environ.get("STRIPE_PRO_PRICE_ID")
     STRIPE_WEBHOOK_SECRET = os.environ.get("STRIPE_WEBHOOK_SECRET")
 
-    # Pricing Display (update when Stripe price changes)
+    # Chargebee Settings (if BILLING_PROVIDER=chargebee)
+    CHARGEBEE_SITE = os.environ.get("CHARGEBEE_SITE")
+    CHARGEBEE_API_KEY = os.environ.get("CHARGEBEE_API_KEY")
+    CHARGEBEE_PRO_ITEM_PRICE_ID = os.environ.get("CHARGEBEE_PRO_ITEM_PRICE_ID")
+    CHARGEBEE_WEBHOOK_USERNAME = os.environ.get("CHARGEBEE_WEBHOOK_USERNAME")
+    CHARGEBEE_WEBHOOK_PASSWORD = os.environ.get("CHARGEBEE_WEBHOOK_PASSWORD")
+
+    # Pricing Display (update when price changes)
     PRO_PRICE_DISPLAY = os.environ.get("PRO_PRICE_DISPLAY", "$29")
     PRO_PRICE_INTERVAL = os.environ.get("PRO_PRICE_INTERVAL", "month")

--- a/enferno/user/models.py
+++ b/enferno/user/models.py
@@ -235,12 +235,13 @@ class Activity(db.Model, BaseMixin):
         return activity
 
 
-class StripeEvent(db.Model, BaseMixin):
-    """Durable store for processed Stripe webhook events (idempotency)."""
+class BillingEvent(db.Model, BaseMixin):
+    """Durable store for processed billing webhook events (idempotency)."""
 
     id = db.Column(db.Integer, primary_key=True)
     event_id = db.Column(db.String(255), unique=True, nullable=False)
     event_type = db.Column(db.String(128), nullable=True)
+    provider = db.Column(db.String(20), nullable=True)  # 'stripe' or 'chargebee'
 
 
 class Workspace(db.Model, BaseMixin):

--- a/enferno/user/models.py
+++ b/enferno/user/models.py
@@ -254,7 +254,7 @@ class Workspace(db.Model, BaseMixin):
 
     # Billing fields
     plan = db.Column(db.String(10), default="free")  # 'free' or 'pro'
-    stripe_customer_id = db.Column(db.String(100), nullable=True)
+    billing_customer_id = db.Column(db.String(100), nullable=True)
     upgraded_at = db.Column(db.DateTime, nullable=True)
 
     owner = relationship(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dependencies = [
     "sluggi>=0.1.1",
     # Payments and billing
     "stripe>=12.0.0",
+    "chargebee>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,19 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592 },
+]
+
+[[package]]
 name = "argon2-cffi"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -351,6 +364,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/11/74/539e56497d9bd1d484fd863dd69cbbfa653cd2aa27abfe35653494d85e94/cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560", size = 7114 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/55/51844dd50c4fc7a33b653bfaba4c2456f06955289ca770a5dbd5fd267374/cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9", size = 7249 },
+]
+
+[[package]]
+name = "chargebee"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/85/d47840d85e02c4bed5727d1f57d8751d4187ff2a256314941b752529bee4/chargebee-3.16.0.tar.gz", hash = "sha256:c9c2cdcdc68195745b86b060f6fbfb23b425654f7eaf98598649b52ecfee486f", size = 260361 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/9f/680b10a10228d0530101cf26cef0987eb4d5c21eaa97549efd83affcf8f6/chargebee-3.16.0-py3-none-any.whl", hash = "sha256:c4c993113b11b743a3131aea92a99333c4b24feafeb34c34bd0ea19294411fbe", size = 357170 },
 ]
 
 [[package]]
@@ -857,6 +882,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/34/72/9614c465dc206155d93eff0ca20d42e1e35afc533971379482de953521a4/gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec", size = 375031 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/7d/6dac2a6e1eba33ee43f318edbed4ff29151a49b5d37f080aad1e6469bca4/gunicorn-23.0.0-py3-none-any.whl", hash = "sha256:ec400d38950de4dfd418cff8328b2c8faed0edb0d517d3394e457c317908ca4d", size = 85029 },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
 ]
 
 [[package]]
@@ -1588,6 +1650,7 @@ dependencies = [
     { name = "bleach" },
     { name = "blinker" },
     { name = "cffi" },
+    { name = "chargebee" },
     { name = "click" },
     { name = "cryptography" },
     { name = "email-validator" },
@@ -1663,6 +1726,7 @@ requires-dist = [
     { name = "blinker", specifier = ">=1.9.0" },
     { name = "celery", marker = "extra == 'full'", specifier = ">=5.5.3" },
     { name = "cffi", specifier = ">=1.17.1" },
+    { name = "chargebee", specifier = ">=3.0.0" },
     { name = "click", specifier = ">=8.2.1" },
     { name = "cryptography", specifier = ">=45.0.5" },
     { name = "email-validator", specifier = ">=2.2.0" },


### PR DESCRIPTION
  Adds Chargebee support alongside Stripe. Provider selected via `BILLING_PROVIDER` env var.                                     
                                                                                                                                 
  **Changes:**                                                                                                                   
  - `HostedBilling` class with identical interface for both providers                                                            
  - Webhook handlers with provider-specific auth (HMAC for Stripe, Basic Auth for Chargebee)                                     
  - Renamed `stripe_customer_id` → `billing_customer_id`, `StripeEvent` → `BillingEvent`                                         
  - Updated docs with setup instructions for both providers                                                                      
                                                                                                                                 
  **Note:** Choose provider before production—switching requires manual customer migration.                                      
                                                                                                                                 
